### PR TITLE
[IMPROVEMENT] Lookup instead of importing modal model

### DIFF
--- a/addon/services/modal.js
+++ b/addon/services/modal.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
-import ModalModel from 'ember-modal-service/models/modal';
 
 const {
 	A,
 	isEmpty,
 	Service,
-	get
+	get,
+	getOwner
 } = Ember;
 
 /**
@@ -91,6 +91,7 @@ export default Service.extend({
 	 * @return Promise
 	 */
 	open(name, options = {}) {
+		const ModalModel = getOwner(this).factoryFor('model:modal');
 		const modal = ModalModel.create({ name, options });
 
 		// If the modal is already opened, reject it

--- a/tests/unit/services/modal-test.js
+++ b/tests/unit/services/modal-test.js
@@ -16,7 +16,9 @@ let service;
 moduleFor('service:modal', 'Unit | Service | modal', {
 	beforeEach() {
 		service = this.subject();
-	}
+	},
+
+	needs: ['model:modal']
 });
 
 test('it has an empty array on init', (assert) => {


### PR DESCRIPTION
By looking up the modal model factory from the owner, it can be overwritten on application level. This for example enables the user to change the convention modal component names are generated by only extending the model.

This change is only compatible with Ember >= 2.13 (https://www.emberjs.com/deprecations/v2.x/#toc_id-container-lookupfactory).