### PR TITLE
Pass more than one param from the `modal` template to the `resolve`/`reject`

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -228,7 +228,7 @@ export default Component.extend({
 		 * @method resolve
 		 */
 		resolve() {
-			this.resolve(Array.prototype.slice.apply(args));
+			this.resolve([...arguments]);
 		},
 
 		/**
@@ -238,7 +238,7 @@ export default Component.extend({
 		 * @method reject
 		 */
 		reject() {
-			this.reject(Array.prototype.slice.apply(args));
+			this.reject([...arguments]);
 		}
 
 	}

--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -227,8 +227,8 @@ export default Component.extend({
 		 *
 		 * @method resolve
 		 */
-		resolve() {
-			this.resolve([...arguments]);
+		resolve(...args) {
+			this.resolve(args.length > 1 ? args : args[0]);
 		},
 
 		/**
@@ -237,8 +237,8 @@ export default Component.extend({
 		 *
 		 * @method reject
 		 */
-		reject() {
-			this.reject([...arguments]);
+		reject(...args) {
+			this.reject(args.length > 1 ? args : args[0]);
 		}
 
 	}

--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -228,7 +228,7 @@ export default Component.extend({
 		 * @method resolve
 		 */
 		resolve() {
-			this.resolve(...arguments);
+			this.resolve(Array.prototype.slice.apply(args));
 		},
 
 		/**
@@ -238,7 +238,7 @@ export default Component.extend({
 		 * @method reject
 		 */
 		reject() {
-			this.reject(...arguments);
+			this.reject(Array.prototype.slice.apply(args));
 		}
 
 	}


### PR DESCRIPTION
The README states:

Base modal component provides resolve & reject actions so you can implement basic closing behaviour directly on the template. You can pass any arguments you want the modal to be resolved / rejected with

```<button {{action "reject" "foo" "bar"}}>Close modal</button>```

This is a great feature as it allows the modal to resolve with as many params as we want.

However, currently this does not work as `resolve`/`reject` only allows one param by design.

This PR addressed that by wrapping the multiple arguments into an array.

This makes the resolution signature slightly ambiguous but prevents the breaking change for the current users of the addon.

Could you guys please share what you think is the best approach going forward. @shokmaster @josex2r 

1. What we have in this PR
2. Bump the major version of this addon and always return an Array in the `resolve`/`reject` for consistency. 