### PR TITLE
Removed 'oh' class name.

### DIFF
--- a/addon/components/modal-container.js
+++ b/addon/components/modal-container.js
@@ -17,14 +17,6 @@ export default Component.extend({
 	layout,
 
 	/**
-	 * Class names.
-	 *
-	 * @property classNames
-	 * @type Array
-	 */
-	classNames: ['oh'],
-
-	/**
 	 * Binded CSS classes.
 	 *
 	 * @property classNameBindings


### PR DESCRIPTION
'oh' css class name must be removed to prevent the loss of focus