### PR TITLE
fix: util on-transition-end modified to listen only modal events

### DIFF
--- a/addon/utils/css-transitions/on-transition-end.js
+++ b/addon/utils/css-transitions/on-transition-end.js
@@ -35,18 +35,22 @@ const transitionEndEventName = findTransitionEventName();
  */
 export default function onTransitionEnd(element, callback, transitionProperty = 'all', once = false) {
 	const fn = (e) => {
-		const { propertyName, type } = e;
+		const { propertyName, type, target } = e;
+
+		if (element !== target) {
+			return;
+		}
 
 		if (transitionProperty !== 'all' && propertyName !== transitionProperty) {
 			return;
 		}
 
 		if (once) {
-			element.removeEventListener(type, fn, true);
+			element.removeEventListener(type, fn);
 		}
 
 		run(null, callback, e);
 	};
 
-	element.addEventListener(transitionEndEventName, fn, true);
+	element.addEventListener(transitionEndEventName, fn);
 }

--- a/tests/unit/utils/css-transitions/on-transition-end-test.js
+++ b/tests/unit/utils/css-transitions/on-transition-end-test.js
@@ -142,3 +142,28 @@ test('it waits for any element transition once', (assert) => {
 		done();
 	}, 600);
 });
+
+test('it ignores transition of child element', (assert) => {
+	const done = assert.async();
+	const element = createElement();
+	const childElement = document.createElement('div');
+	const fn = spy();
+
+	element.appendChild(childElement);
+	childElement.style.transition = 'background-color .2s linear 0s';
+
+	onTransitionEnd(element, fn, 'background-color');
+
+	setAnimationStyle(childElement, 'backgroundColor', 'green');
+
+	setTimeout(() => {
+		assert.ok(fn.notCalled, 'fn is not called');
+
+		setAnimationStyle(childElement, 'backgroundColor', 'red');
+	}, 300);
+
+	setTimeout(() => {
+		assert.ok(fn.notCalled, 'fn is still not called');
+		done();
+	}, 600);
+});


### PR DESCRIPTION
Changes added to the util ```onTransitionEnd``` function to fire callback only when transition for modal component triggered but not for child components