### PR TITLE
feat: remove the instance of $() and replace with this.element

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -167,7 +167,7 @@ export default Component.extend({
 		}
 
 		const scheduler = this.get('scheduler');
-		const element = this.$().get(0);
+		const element = this.element;
 
 		// Close modal.
 		this.set('visible', false);


### PR DESCRIPTION
Since Ember is showing deprecation warnings for jQuery for Ember 4.0 now and Octane defaults jQuery to off, removing jQuery dependency. Since it can also be turned off in current versions of ember (although not default), it would be nice to remove the need for jQuery. 
- Remove dependence on jQuery