### PR TITLE
feat: Remove presentation classes

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -32,14 +32,6 @@ export default Component.extend({
 	modal: service('modal'),
 
 	/**
-	 * HTML class name bindings.
-	 *
-	 * @property classNameBindings
-	 * @type Array
-	 */
-	classNameBindings: ['model.options.hasOverlay:modal-overlay:modal-view'],
-
-	/**
 	 * HTML attributes bindings.
 	 *
 	 * @property attributeBindings


### PR DESCRIPTION
The presentation classes should be part of the application, not the addon. Because they depend on CSS