### PR TITLE
feat: add ability to provide a prefix for modals

### DIFF
--- a/addon/models/modal.js
+++ b/addon/models/modal.js
@@ -29,7 +29,7 @@ export default class ModalModel extends EmberObject.extend(PromiseProxyMixin) {
 			throw new Error('Modal must have a name.');
 		}
 
-		if(prefix) {
+		if (prefix) {
 			return `${prefix}${dasherize(name)}`;
 		}
 

--- a/addon/models/modal.js
+++ b/addon/models/modal.js
@@ -20,12 +20,17 @@ export default class ModalModel extends EmberObject.extend(PromiseProxyMixin) {
 
 	@oneWay('_deferred.promise') promise;
 
-	@computed('name')
+	@computed('name', 'options.prefix')
 	get fullname() {
 		const name = this.name;
+		const prefix = this.options && this.options.prefix ? this.options.prefix : null;
 
 		if (isBlank(name)) {
 			throw new Error('Modal must have a name.');
+		}
+
+		if(prefix) {
+			return `${prefix}${dasherize(name)}`;
 		}
 
 		return `modal-${dasherize(name)}`;

--- a/tests/unit/models/modal-test.js
+++ b/tests/unit/models/modal-test.js
@@ -23,19 +23,15 @@ module('Unit | Model | modal', (hooks) => {
 	});
 
 	test('it has a fullname with prefix when a prefix is provided', (assert) => {
-		const options = { prefix: "modals/" };
+		const options = { prefix: 'modals/' };
 
 		model = factory.create({ name, options });
 
 		assert.equal(model.get('fullname'), `modals/${name}`);
-	})
+	});
 
-	test('it throws an error if modal has not a name', function(assert) {
-		assert.throws(() => {
-			const factory = this.owner.factoryFor('model:modal');
-
-			factory.create();
-		}, Error, 'Modal must have a name.');
+	test('it throws an error if modal has not a name', (assert) => {
+		assert.throws(() => factory.create(), Error, 'Modal must have a name.');
 	});
 
 	test('it setups the promise and fullname objects on init', (assert) => {

--- a/tests/unit/models/modal-test.js
+++ b/tests/unit/models/modal-test.js
@@ -5,6 +5,7 @@ import ModalModel from 'ember-modal-service/models/modal';
 const name = 'foo';
 
 let model;
+let factory;
 
 module('Unit | Model | modal', (hooks) => {
 	setupTest(hooks);
@@ -12,7 +13,7 @@ module('Unit | Model | modal', (hooks) => {
 	hooks.beforeEach(function() {
 		this.owner.register('model:modal', ModalModel);
 
-		const factory = this.owner.factoryFor('model:modal');
+		factory = this.owner.factoryFor('model:modal');
 
 		model = factory.create({ name });
 	});
@@ -20,6 +21,14 @@ module('Unit | Model | modal', (hooks) => {
 	test('it has a fullname when has a name', (assert) => {
 		assert.equal(model.get('fullname'), `modal-${name}`);
 	});
+
+	test('it has a fullname with prefix when a prefix is provided', (assert) => {
+		const options = { prefix: "modals/" };
+
+		model = factory.create({ name, options });
+
+		assert.equal(model.get('fullname'), `modals/${name}`);
+	})
 
 	test('it throws an error if modal has not a name', function(assert) {
 		assert.throws(() => {


### PR DESCRIPTION
I would like to make it possible for modals to live outside of the main components folder. This allows custom prefixes on the name, which adds additional flexibility to where you can put your modals in your folder structure.

This allows something along these lines:
```
this.modal.open("info-modal", { prefix: "modals/" })
```

The `info-modal` can now live inside `components/modals/info-modal`. With a significant number of modals in an application, it can become unweidly to have a lot of top level `modal-` modals.

The default fallback returns `modal-${name}` as it did before.